### PR TITLE
Fix sticky footer initialization

### DIFF
--- a/resources/scripts/footer-sticky.js
+++ b/resources/scripts/footer-sticky.js
@@ -12,5 +12,6 @@ const checkFooterSticky = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  checkFooterSticky();
   window.addEventListener('resize', checkFooterSticky);
 });


### PR DESCRIPTION
## Summary
- ensure sticky footer logic runs on initial page load

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_683fc879826c83268a6b8894a97ae8d1