### PR TITLE
Fix code block handling

### DIFF
--- a/build/buildBlogPosts.js
+++ b/build/buildBlogPosts.js
@@ -91,8 +91,10 @@ async function main() {
         } else if (block.type === "quote") {
           content += `> ${block.quote.rich_text.map(text => text.plain_text).join("")}\n\n`;
         } else if (block.type === "code") {
-          content += ""
-} else {
+          const lang = block.code.language || "";
+          const codeText = block.code.rich_text.map(text => text.plain_text).join("");
+          content += `\n\n\`\`\`${lang}\n${codeText}\n\`\`\`\n\n`;
+        } else {
           // Handle other block types as needed, or ignore them
           console.log(`Skipping unsupported block type: ${block.type}`);
         }

--- a/index.html
+++ b/index.html
@@ -181,3 +181,5 @@
     <script src="resources/scripts/audio-player.js"></script>
     <script src="resources/scripts/share/share-handler.js"></script>
 </body>
+</html>
+


### PR DESCRIPTION
## Summary
- handle Notion code blocks in blog post builder
- close the html document

## Testing
- `npm install`
- `NOTION_POST_DATABASE_ID=foo NOTION_TOKEN=bar node build/buildBlogPosts.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683fc89321948326adbb8ffe549c2f10