### PR TITLE
Add GA event for shares

### DIFF
--- a/resources/scripts/share/share-handler.js
+++ b/resources/scripts/share/share-handler.js
@@ -10,6 +10,12 @@ if(shareButton) {
         text: "Check out this author's site!",
         url: window.location.href
       });
+      if (typeof gtag === 'function') {
+        gtag('event', 'share', {
+          'event_category': 'Engagement',
+          'event_label': 'native'
+        });
+      }
     } else {
       console.log("Fallback share");
       const sharingModalElement = document.getElementById('shareModal');
@@ -39,7 +45,7 @@ const handleShare= platform => {
     const pageUrl = encodeURIComponent(window.location.href);
     const pageTitle = encodeURIComponent(document.title);
   
-    switch (platform) {
+  switch (platform) {
       case 'reddit':
         shareToReddit(pageUrl, pageTitle);
         break;
@@ -57,6 +63,12 @@ const handleShare= platform => {
         break;
       default:
         console.warn('Unknown sharing platform:', platform);
+    }
+    if (typeof gtag === 'function') {
+      gtag('event', 'share', {
+        'event_category': 'Engagement',
+        'event_label': platform
+      });
     }
 }
 


### PR DESCRIPTION
## Summary
- track native share usage in share handler
- fire GA share event for each platform

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407651a5d0832698f86ae46327d5f4