### PR TITLE
Fix sticky footer initialization

### DIFF
--- a/resources/scripts/footer-sticky.js
+++ b/resources/scripts/footer-sticky.js
@@ -15,3 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
   checkFooterSticky();
   window.addEventListener('resize', checkFooterSticky);
 });
+
+// Ensure the footer position is recalculated after all resources such as
+// images have loaded. This helps with pages that dynamically add content
+// or include images that change the overall height after DOMContentLoaded.
+window.addEventListener('load', checkFooterSticky);


### PR DESCRIPTION
## Summary
- update sticky footer helper to run on window load

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840882b25088326a7607e20acb54225