### PR TITLE
Fix sticky footer detection for blog

### DIFF
--- a/resources/scripts/footer-sticky.js
+++ b/resources/scripts/footer-sticky.js
@@ -1,5 +1,5 @@
 const checkFooterSticky = () => {
-  const contentHeight = document.documentElement.scrollHeight;
+  const contentHeight = document.body.scrollHeight;
   const viewportHeight = window.innerHeight;
   const footer = document.querySelector('footer');
   const footerHeight = footer ? footer.offsetHeight : 0;
@@ -19,4 +19,9 @@ const checkFooterSticky = () => {
 document.addEventListener('DOMContentLoaded', () => {
   checkFooterSticky();
   window.addEventListener('resize', checkFooterSticky);
+  const offcanvas = document.getElementById('offcanvas');
+  if (offcanvas) {
+    offcanvas.addEventListener('hidden.bs.offcanvas', checkFooterSticky);
+    offcanvas.addEventListener('shown.bs.offcanvas', checkFooterSticky);
+  }
 });


### PR DESCRIPTION
## Summary
- improve footer height calculation by using body.scrollHeight
- recalc sticky footer when blog post list offcanvas opens or closes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6840958b82e8832692b98194a5bcf6bb